### PR TITLE
install_scoop.cmd: Improve grammar

### DIFF
--- a/wingetui/resources/install_scoop.cmd
+++ b/wingetui/resources/install_scoop.cmd
@@ -1,5 +1,5 @@
 @echo off
-echo This script is going to install scoop and the dependencies required by WingetUI.
+echo This script will install Scoop and the dependencies required by WingetUI.
 pause
 powershell -NoProfile -Command "Set-ExecutionPolicy RemoteSigned -Scope CurrentUser"
 echo Installing scoop...


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/67732686/195087364-4169d17e-b322-493d-b06f-dcac974bf8d0.png)

On a more serious note, and regarding [previous](https://github.com/martinet101/WingetUI/issues/177) [discussions](https://github.com/martinet101/WingetUI/issues/101), some things to keep in mind:

* We want to keep the sentences as effective (i.e., short and clear) and at the same time as grammatically correct as possible – specifically because we're dealing with something being presented in a CLI environment.
* Why do we want to capitalize the first letter of Scoop? There are two things that are important to separate:

#

1. Scoop as a product name.

![image](https://user-images.githubusercontent.com/67732686/195090550-e92f19d6-2c67-4cb3-abf0-64f31b93da8c.png)

Notice how every instance is capitalized, as expected.

#

2. Working with Scoop, which is primarily through a CLI;

![image](https://user-images.githubusercontent.com/67732686/195088304-8206fb03-279a-479c-a8ad-fb820f82328c.png)

![image](https://user-images.githubusercontent.com/67732686/195088368-1b1d8bcc-90a9-4b3a-add4-7432bd2a1422.png)

During operation, the typography is based on operating within a CLI environment, which in this case means only using lower case lettering.

---

So, we want to make the sentence more effective, and we want to describe Scoop in the form of a product name. 

Therefore, regarding the last part, we want to capitalize the first letter in this instance.