### PR TITLE
small context menu inconsistency

### DIFF
--- a/wingetui/uiSections.py
+++ b/wingetui/uiSections.py
@@ -213,7 +213,7 @@ class DiscoverSoftwareSection(QWidget):
         
         tooltips = {
             self.upgradeSelected: _("Install package"),
-            inf: _("Show package info"),
+            inf: _("Show info"),
             ins2: _("Run the installer with administrator privileges"),
             ins3: _("Skip the hash check"),
             ins4: _("Interactive installation"),


### PR DESCRIPTION
Installed Packages option is "show package info" instead of "show info".  Should I have changed the other way around? I think changing here is better than in Tolgee because other translations would continue different if I changed only the English version there.

![Captura de tela 2022-10-17 230053](https://user-images.githubusercontent.com/73800734/196326194-f155fa65-db6b-4210-8512-da7e25d3a881.png)
![Captura de tela 2022-10-17 230101](https://user-images.githubusercontent.com/73800734/196326196-6ef26304-0891-4169-99ce-d8c3cc0226e0.png)
![Captura de tela 2022-10-17 230043](https://user-images.githubusercontent.com/73800734/196326197-c11733e8-788a-4dd4-a4be-97ba7ceb3629.png)
