### PR TITLE
Fix "General preferences" untranslated in other languages

### DIFF
--- a/wingetui/uiSections.py
+++ b/wingetui/uiSections.py
@@ -1929,7 +1929,7 @@ class SettingsSection(QScrollArea):
         self.layout.addWidget(title)
         self.layout.addSpacing(20)
 
-        self.generalTitle = QSettingsTitle("General Preferences", getMedia("settings"), "Language, theme and other miscellaneous preferences")
+        self.generalTitle = QSettingsTitle("General preferences", getMedia("settings"), "Language, theme and other miscellaneous preferences")
         self.layout.addWidget(self.generalTitle)
 
         self.language = QSettingsComboBox(_("WingetUI display language:")+" (Language)")

--- a/wingetui/uiSections.py
+++ b/wingetui/uiSections.py
@@ -1929,7 +1929,7 @@ class SettingsSection(QScrollArea):
         self.layout.addWidget(title)
         self.layout.addSpacing(20)
 
-        self.generalTitle = QSettingsTitle("General preferences", getMedia("settings"), "Language, theme and other miscellaneous preferences")
+        self.generalTitle = QSettingsTitle(_("General preferences"), getMedia("settings"), "Language, theme and other miscellaneous preferences")
         self.layout.addWidget(self.generalTitle)
 
         self.language = QSettingsComboBox(_("WingetUI display language:")+" (Language)")


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/71824258/198842685-6d7bdfac-f94e-429b-8859-748eb747f7b5.png)

After:
![image](https://user-images.githubusercontent.com/71824258/198842702-9bd05216-35aa-47fc-8dde-0786c1151ed2.png)
